### PR TITLE
Fix aws_s3_bucket_versioning configs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,13 @@ resource "aws_s3_bucket" "this" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = var.versioning_status
+  }
+}
+
 resource "aws_s3_bucket_logging" "this" {
   count  = contains(keys(var.bucket_logging_target), "bucket") ? 1 : 0
   bucket = aws_s3_bucket.this.id

--- a/variables.tf
+++ b/variables.tf
@@ -66,10 +66,10 @@ variable "bucket_logging_target" {
   # }
 }
 
-variable "versioning" {
-  type        = bool
-  description = "Toggle for versioning the bucket. Defaults to true"
-  default     = true
+variable "versioning_status" {
+  type        = string
+  description = "Toggle for versioning the bucket. Defaults to Enabled"
+  default     = "Enabled"
 }
 
 variable "object_ownership" {


### PR DESCRIPTION
Updates the `versioning_status` variable to be a string so that the AWS bucket versioning state can be modelled (Enabled, Suspended, or Disabled). Fixes an issue where the versioning status was not correctly added to the bucket.